### PR TITLE
Add environment variable to trigger auto update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
             - DB_PASSWORD=root
             - SUPERUSER_NAME=admin
             - SUPERUSER_PASSWORD=secret
+            - CODEDX_AUTOUPDATE=true
         volumes:
             - codedx-appdata-volume:/opt/codedx
         ports:


### PR DESCRIPTION
**_Related task:_** https://trello.com/c/amWLSooD/116-invoke-code-dx-update-from-setup-script
_Dependent on_: https://github.com/codedx/codedx/compare/dev/v5.4.x...feature/prevent-update-page-in-docker-instance?expand=1

As per the trello card, this PR "minimizes" the likelihood of the update page appearing in a code dx docker instance (likelihood should actually always be 0). 

Via the environment variable `CODEDX_AUTOUPDATE`, codedx will automatically update before the web server is accessible, so users should not see the `/codedx/update` page any more.

Successfully tested with the following image `937101340859.dkr.ecr.us-east-2.amazonaws.com/codedx/codedx-tomcat:762f3be1eb`

I'm unsure of what the process is for updating the tomcat image (do we wait until next release with the included change from the codedx repo?)

![image](https://user-images.githubusercontent.com/28029704/120507899-3617b980-c395-11eb-9869-c4d753a2c91a.png)
![image](https://user-images.githubusercontent.com/28029704/120510577-8db72480-c397-11eb-9503-79f34b82aa12.png)
