### PR TITLE
fix: Remove tomcat version in default 404 page

### DIFF
--- a/server.xml
+++ b/server.xml
@@ -175,6 +175,12 @@
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 
+        <!-- Error report valve controls the 404 page tomcat uses
+             and allows us to remove the tomcat version from the default page.
+             https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Error_Report_Valve -->
+        <Valve className="org.apache.catalina.valves.ErrorReportValve"
+               showReport="true"
+               showServerInfo="false" />
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
https://trello.com/c/ZFCTlKhG/295-harden-the-k8s-code-dx-tomcat-docker-image

Update the default template `server.xml` to hide tomcat server version on error pages.