### PR TITLE
fix: Quote JDBC url because of forbidden characters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     codedx-tomcat:
         image: codedx/codedx-tomcat:v5.4.15.2
         environment:
-            - DB_URL=jdbc:mysql://codedx-db/codedx?sessionVariables=sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
+            - DB_URL="jdbc:mysql://codedx-db/codedx?sessionVariables=sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'"
             - DB_DRIVER=com.mysql.jdbc.Driver
             - DB_USER=root
             - DB_PASSWORD=root


### PR DESCRIPTION
The Tomcat JDBC URL contains characters that cause HOCON parsing to fail (the `?`, refer to forbidden HOCON characters [here](https://github.com/lightbend/config/blob/master/HOCON.md#unquoted-strings)). Once HOCON fails, the Properties format is used instead to parse the `.props` file. Our default way of parsing the `.props` file should not fail.