### PR TITLE
fix: Use YAML dictionary when specifying environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,66 +63,6 @@ You can mount your cacerts file by adding a line to the volumes list in the code
 
 >Note: Append `:Z` to the extra volume mount when using [selinux](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label).
 
-### Custom Props
-
-Code Dx's features can be customized through the configuration file `codedx.props` which, by default, is located in your tomcat container's `codedx-appdata` volume (typically located at `/opt/codedx`). A full list of configuration parameters and how to change them can be found at [Install Guide](https://codedx.com/Documentation/InstallGuide.html#CodeDxPropertiesFile).
-
-For example, if it wasn't desired for Code Dx to remember the username used to login or persist login sessions, then the property `swa.user.rememberme` can be changed from `full` to `off`.
-
-Here's how this can be done in a Docker Compose install:
-
-1. Start your Code Dx Tomcat container
-
-With our working directory set to where our `docker-compose.yml` file resides, the Tomcat container configured by the `codedx-tomcat` service can be started with the command:
-
-```bash
-docker-compose start codedx-tomcat
-```
-
-2. Copy `/opt/codedx/codedx.props` locally
-
-Here we're copying the `codedx.props` file out of the Tomcat container into our local working directory `.`. You can change the destination of this file to something like `C:\Users\[username]\Documents` or `/home/[username]/` where it's more easily accessible, as we'll need to be editing this file later.
-
-You can find the name of your container with `docker container ls --filter name=tomcat` and use that in place of `codedx-docker_codedx-tomcat_1` if yours varies.
-
-```bash
-docker cp codedx-docker_codedx-tomcat_1:/opt/codedx/codedx.props .
-```
-
-3. Edit your local codedx.props (switching from full to off)
-
-From where you copied `codedx.props` to in the last step, open it with your preferred text editor and change the line
-
-```yaml
-swa.user.rememberme = full
-```
-
-to
-
-```yaml
-swa.user.rememberme = off
-```
-
-Code Dx won't remember usernames or persist sessions once we configure Code Dx with the new props file.
-
-4. Copy codedx.props back
-
-If you're in the same directory as where you copied your props file to, and the tomcat container is running, then we run the following command to replace the old props file in the container with the new one:
-
-```bash
-docker cp codedx.props codedx-docker_codedx-tomcat_1:/opt/codedx/codedx.props
-```
-
-5. Restart your container
-
-Code Dx loads the configuration files on boot, therefore we'll need to restart our tomcat container for our new settings to be properly reflected.
-
-```bash
-docker restart codedx-docker_codedx-tomcat_1
-```
-
-(If you want to stop the Tomcat container running in the background run the command `docker compose stop codedx-tomcat`)
-
 ### HTTP Over SSL
 
 This Tomcat container can support HTTP over SSL. For example, generate a self-signed certificate with `openssl` (or better yet, obtain a real certificate from a certificate authority):

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can mount your cacerts file by adding a line to the volumes list in the code
 
 ```yaml
     codedx-tomcat:
-        image: codedx/codedx-tomcat:v5.4.15.1
+        image: codedx/codedx-tomcat:v5.5.0
         environment:
             - DB_URL=jdbc:mysql://codedx-db/codedx
             - DB_DRIVER=com.mysql.jdbc.Driver
@@ -139,7 +139,7 @@ Update your codedx-tomcat section with SSL and server.xml volume mounts and swit
 
 ```yaml
     codedx-tomcat:
-        image: codedx/codedx-tomcat:v5.4.15.1
+        image: codedx/codedx-tomcat:v5.5.0
         environment:
             - DB_URL=jdbc:mysql://codedx-db/codedx
             - DB_DRIVER=com.mysql.jdbc.Driver

--- a/README.md
+++ b/README.md
@@ -101,7 +101,3 @@ Update your codedx-tomcat section with SSL and server.xml volume mounts and swit
 >Note: Append `:Z` to the extra volume mounts when using [selinux](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label).
 
 After following the rest of each method's respective setup instructions, Code Dx should now be available over https at the following url: https://localhost:8443/codedx
-
-### Parsing Configuration
-
-If you want to treat quoted values literally in the `codedx-tomcat` service's `environment`, e.g. `DB_PASSWORD="my_password"`, you can add the following environment variable setting: `TRANSFORM_LIST_PARSING=False`. After starting/restarting your `codedx-tomcat` service, quotes will be treated literally for the value of your environment variables.

--- a/README.md
+++ b/README.md
@@ -161,3 +161,7 @@ Update your codedx-tomcat section with SSL and server.xml volume mounts and swit
 >Note: Append `:Z` to the extra volume mounts when using [selinux](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label).
 
 After following the rest of each method's respective setup instructions, Code Dx should now be available over https at the following url: https://localhost:8443/codedx
+
+### Parsing Configuration
+
+If you want to treat quoted values literally in the `codedx-tomcat` service's `environment`, e.g. `DB_PASSWORD="my_password"`, you can add the following environment variable setting: `TRANSFORM_LIST_PARSING=False`. After starting/restarting your `codedx-tomcat` service, quotes will be treated literally for the value of your environment variables.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ swa.user.rememberme = full
 
 to
 
-```
+```yaml
 swa.user.rememberme = off
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,66 @@ You can mount your cacerts file by adding a line to the volumes list in the code
 
 >Note: Append `:Z` to the extra volume mount when using [selinux](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label).
 
+### Custom Props
+
+Code Dx's features can be customized through the configuration file `codedx.props` which, by default, is located in your tomcat container's `codedx-appdata` volume (typically located at `/opt/codedx`). A full list of configuration parameters and how to change them can be found at [Install Guide](https://codedx.com/Documentation/InstallGuide.html#CodeDxPropertiesFile).
+
+For example, if it wasn't desired for Code Dx to remember the username used to login or persist login sessions, then the property `swa.user.rememberme` can be changed from `full` to `off`.
+
+Here's how this can be done in a Docker Compose install:
+
+1. Start your Code Dx Tomcat container
+
+With our working directory set to where our `docker-compose.yml` file resides, the Tomcat container configured by the `codedx-tomcat` service can be started with the command:
+
+```bash
+docker-compose start codedx-tomcat
+```
+
+2. Copy `/opt/codedx/codedx.props` locally
+
+Here we're copying the `codedx.props` file out of the Tomcat container into our local working directory `.`. You can change the destination of this file to something like `C:\Users\[username]\Documents` or `/home/[username]/` where it's more easily accessible, as we'll need to be editing this file later.
+
+You can find the name of your container with `docker container ls --filter name=tomcat` and use that in place of `codedx-docker_codedx-tomcat_1` if yours varies.
+
+```bash
+docker cp codedx-docker_codedx-tomcat_1:/opt/codedx/codedx.props .
+```
+
+3. Edit your local codedx.props (switching from full to off)
+
+From where you copied `codedx.props` to in the last step, open it with your preferred text editor and change the line
+
+```yaml
+swa.user.rememberme = full
+```
+
+to
+
+```
+swa.user.rememberme = off
+```
+
+Code Dx won't remember usernames or persist sessions once we configure Code Dx with the new props file.
+
+4. Copy codedx.props back
+
+If you're in the same directory as where you copied your props file to, and the tomcat container is running, then we run the following command to replace the old props file in the container with the new one:
+
+```bash
+docker cp codedx.props codedx-docker_codedx-tomcat_1:/opt/codedx/codedx.props
+```
+
+5. Restart your container
+
+Code Dx loads the configuration files on boot, therefore we'll need to restart our tomcat container for our new settings to be properly reflected.
+
+```bash
+docker restart codedx-docker_codedx-tomcat_1
+```
+
+(If you want to stop the Tomcat container running in the background run the command `docker compose stop codedx-tomcat`)
+
 ### HTTP Over SSL
 
 This Tomcat container can support HTTP over SSL. For example, generate a self-signed certificate with `openssl` (or better yet, obtain a real certificate from a certificate authority):

--- a/docker-compose-external-db.yml
+++ b/docker-compose-external-db.yml
@@ -20,12 +20,12 @@ services:
     codedx-tomcat:
         image: codedx/codedx-tomcat:v5.5.0
         environment:
-            - DB_URL=jdbc:mysql://codedx-db/codedxdb?sessionVariables=sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
-            - DB_DRIVER=com.mysql.jdbc.Driver
-            - DB_USER=root
-            - DB_PASSWORD=root
-            - SUPERUSER_NAME=admin
-            - SUPERUSER_PASSWORD=secret
+            DB_URL: "jdbc:mysql://codedx-db/codedxdb?sessionVariables=sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'"
+            DB_DRIVER: "com.mysql.jdbc.Driver"
+            DB_USER: "root"
+            DB_PASSWORD: "root"
+            SUPERUSER_NAME: "admin"
+            SUPERUSER_PASSWORD: "secret"
         volumes:
             - codedx-appdata-ex-db-volume:/opt/codedx
         ports:

--- a/docker-compose-external-db.yml
+++ b/docker-compose-external-db.yml
@@ -18,7 +18,7 @@
 version: '2'
 services:
     codedx-tomcat:
-        image: codedx/codedx-tomcat:v5.4.15.2
+        image: codedx/codedx-tomcat:v5.5.0
         environment:
             - DB_URL=jdbc:mysql://codedx-db/codedxdb?sessionVariables=sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
             - DB_DRIVER=com.mysql.jdbc.Driver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         volumes:
             - codedx-database-volume:/bitnami/mariadb
     codedx-tomcat:
-        image: codedx/codedx-tomcat:v5.4.15.2
+        image: codedx/codedx-tomcat:v5.5.0
         environment:
             - DB_URL=jdbc:mysql://codedx-db/codedx?sessionVariables=sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
             - DB_DRIVER=com.mysql.jdbc.Driver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,20 +16,20 @@ services:
     codedx-db:
         image: codedx/codedx-mariadb:v1.1.1
         environment:
-            - MARIADB_ROOT_PASSWORD=root
-            - MARIADB_DATABASE=codedx
-            - MARIADB_EXTRA_FLAGS=--optimizer_search_depth=0 --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --lower_case_table_names=1
+            MARIADB_ROOT_PASSWORD: "root"
+            MARIADB_DATABASE: "codedx"
+            MARIADB_EXTRA_FLAGS: "--optimizer_search_depth=0 --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --lower_case_table_names=1"
         volumes:
             - codedx-database-volume:/bitnami/mariadb
     codedx-tomcat:
         image: codedx/codedx-tomcat:v5.5.0
         environment:
-            - DB_URL=jdbc:mysql://codedx-db/codedx?sessionVariables=sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
-            - DB_DRIVER=com.mysql.jdbc.Driver
-            - DB_USER=root
-            - DB_PASSWORD=root
-            - SUPERUSER_NAME=admin
-            - SUPERUSER_PASSWORD=secret
+            DB_URL: "jdbc:mysql://codedx-db/codedx?sessionVariables=sql_mode='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'"
+            DB_DRIVER: "com.mysql.jdbc.Driver"
+            DB_USER: "root"
+            DB_PASSWORD: "root"
+            SUPERUSER_NAME: "admin"
+            SUPERUSER_PASSWORD: "secret"
         volumes:
             - codedx-appdata-volume:/opt/codedx
         ports:


### PR DESCRIPTION


Because of the issue above, it seems there's confusion around how the environment variable values are set (e.g. including quotes when `environment` was a YAML list causes the quotes to be included in the value, whereas the customer expected the quotes to simply be denoting that the value was a string).

The dictionary format allows us to separate out the key from the value (list format treats the whole key,value pair as one string), and then YAML is able to parse the value with quotes and treat it like a string instead of interpreting it as a literal.

This PR updates all examples of YAML configs that are using `environment` as a YAML list to YAML dictionary.

I have double quoted all values to help enforce a standard for future installs. I decided double quotes are better because our `sql_mode` in the JDBC uses single quotes and I thought just enclosing the JDBC in double quotes was cleaner than escaping the single quotes with `''`. (That escape could go unnoticed and lead to some confusion if any values have single quotes, whereas escaping a double quote via `\"` feels more natural to me)

I don't feel super strongly on it however, let me know if single quotes are preferred.

## **Documentation changes were done in a `docs/` branch: https://github.com/codedx/codedx-docker/pull/4/files**